### PR TITLE
add X gender for student model

### DIFF
--- a/lib/clever-ruby/models/student.rb
+++ b/lib/clever-ruby/models/student.rb
@@ -291,7 +291,7 @@ module Clever
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] gender Object to be assigned
     def gender=(gender)
-      validator = EnumAttributeValidator.new('String', ["M", "F", ""])
+      validator = EnumAttributeValidator.new('String', ["M", "F", "X", ""])
       unless validator.valid?(gender)
         fail ArgumentError, "invalid value for 'gender', must be one of #{validator.allowable_values}."
       end


### PR DESCRIPTION
https://app.shortcut.com/operoo/story/11343/clever-sync-issue-live-oak-charter-school

A Student with gender 'X' is failing clever-ruby's student model validation.

![image](https://user-images.githubusercontent.com/1328237/192421187-40d1eb05-c632-4f57-918e-c6f8ba68bef7.png)
